### PR TITLE
Add filter for WP_Query args for get_post_ids()

### DIFF
--- a/escape-ngg.php
+++ b/escape-ngg.php
@@ -254,7 +254,7 @@ class Escape_NextGen_Gallery {
 			'fields'      => 'ids',
 		);
 		
-		$args = apply_filters( 'engg_query_args', $args );
+		$args = apply_filters( 'escape_ngg_query_args', $args );
 		
 		$query = new WP_Query( $args );
 		return $query->posts;

--- a/escape-ngg.php
+++ b/escape-ngg.php
@@ -246,13 +246,17 @@ class Escape_NextGen_Gallery {
 	 * @return void
 	 **/
 	public function get_post_ids() {
-		$query = new WP_Query( array(
+		$args = array(
 			's'           => '[nggallery',
-			'post_type'   => array( 'post', 'page' ),
+			'post_type'   => $post_types,
 			'post_status' => 'any',
 			'nopaging'    => true,
 			'fields'      => 'ids',
-		) );
+		);
+		
+		$args = apply_filters( 'engg_query_args', $args );
+		
+		$query = new WP_Query( $args );
 		return $query->posts;
 	}
 }


### PR DESCRIPTION
Filter the args for WP_Query so that custom post_type can be set, or additional args added like meta_query or tax_query for more direct targeting.
