### PR TITLE
Throw warning when no images were able to be loaded

### DIFF
--- a/escape-ngg.php
+++ b/escape-ngg.php
@@ -189,6 +189,7 @@ class Escape_NextGen_Gallery {
 			$result = media_sideload_image( $url, $post->ID, $hash );
 			if ( is_wp_error( $result ) ) {
 				$this->warnings[] = sprintf( "Error loading %s: %s", $url, $result->get_error_message() );
+				continue;
 			} else {
 				$attachments = get_posts( array(
 					'post_parent' => $post->ID,
@@ -218,6 +219,11 @@ class Escape_NextGen_Gallery {
 			wp_update_post( $attachment );
 			$this->images_count++;
 			$this->infos[] = sprintf( "Added attachment for %d", $post->ID );
+		}
+
+		if ( 0 == $this->images_count ) {
+			$this->warnings[] = sprintf( "Could not load images for nggallery %d", $gallery_id );
+			return;
 		}
 
 		// Construct the [gallery] shortcode


### PR DESCRIPTION
If a gallery has an issue having it's images loaded, a warning should be sent.

I'm open to removing the `return;` in this case, but if it's a fixable issue, without the `return;` then the gallery shortcode would be placed with no way to rerun the script.

Also, I added a `continue;` when there's a WP_Error for media_sideload_image, to prevent notices happening due to $attachments not being set.
