### PR TITLE
Refactoring + support for singlepic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 Escape NextGen Gallery
 ======================
 
-This plugin will scan through all your posts and pages for the [nggallery] shortcode.
+This plugin will scan through all your posts and pages for the [nggallery] and [singlepic] shortcode. This modified version also respects multiple occurences of nggallery tags on a single page or post
 
 It will loop through all images associated with that gallery and recreate them as native WordPress attachments instead. Finally it will replace the [nggallery] shortcode with the [gallery] shortcode native to WordPress.
+
+For all [singlepic] shortcodes it will insert the link and img tag with matching dimension and alignment in the post content and also attach it to the post if it is not already part of the gallery.
 
 ## Instructions
 
 1. **Backup!**
 2. Activate the plugin and browse to yourdomain.com/wp-admin/?escape_ngg_please=1
 3. When you're done you can delete the gallery dir, and the wp_ngg_* tables in your database. Keep the backups though.
-
-## Limitations 
-- doesn't work with shortcodes other than [nggallery]
-- doesn't work when more than one gallery on page
 
 ## Notes
 

--- a/escape-ngg.php
+++ b/escape-ngg.php
@@ -202,6 +202,31 @@ class Escape_NextGen_Gallery {
 
 		foreach ( $images as $image ) {
 
+      $this->attach_image($post_id, $path, $image);
+
+		}
+
+		if ( 0 == $this->images_count ) {
+			$this->warnings[] = sprintf( "Could not load images for nggallery %d", $gallery_id );
+			return;
+		}
+
+		// Construct the [gallery] shortcode
+		$attr = array();
+		if ( $existing_attachments_ids )
+			$attr['exclude'] = implode( ',', $existing_attachments_ids );
+
+		$gallery = '[gallery';
+		foreach ( $attr as $key => $value )
+			$gallery .= sprintf( ' %s="%s"', esc_attr( $key ), esc_attr( $value ) );
+		$gallery .= ']';
+
+    return $gallery;
+  }
+
+
+  private function attach_image($post_id, $path, $image) {
+
 			$url = home_url( trailingslashit( $path['path'] ) . $image->filename );
 			$url = apply_filters( 'engg_image_url', $url, $path['path'], $image->filename );
 			
@@ -242,24 +267,8 @@ class Escape_NextGen_Gallery {
 			wp_update_post( $attachment );
 			$this->images_count++;
 			$this->infos[] = sprintf( "Added attachment for %d", $post_id );
-		}
 
-		if ( 0 == $this->images_count ) {
-			$this->warnings[] = sprintf( "Could not load images for nggallery %d", $gallery_id );
-			return;
-		}
-
-		// Construct the [gallery] shortcode
-		$attr = array();
-		if ( $existing_attachments_ids )
-			$attr['exclude'] = implode( ',', $existing_attachments_ids );
-
-		$gallery = '[gallery';
-		foreach ( $attr as $key => $value )
-			$gallery .= sprintf( ' %s="%s"', esc_attr( $key ), esc_attr( $value ) );
-		$gallery .= ']';
-
-    return $gallery;
+      return $attachment;
   }
 
 


### PR DESCRIPTION
I have refactored the replacement logic to be more modular by using the preg_replace_callback function. This also theoretically enables support for multiple galleries on one page, I haven't tested that, though.

Additionally I added support for replacing the singlepic tag of nggallery while respecting dimensions and alignment options.
